### PR TITLE
feat(settings/docs): clean follow-up for #10 (transcriptionLanguage separation + docs alignment)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Tip: A settings gear in the view header opens the plugin’s settings.
 - **Transcription Language**: Auto/Japanese/English/Chinese/Korean (auto-detection recommended)
 - AI Post‑processing: enable dictionary‑based cleanup (applied to Japanese only)
 - Maximum Recording Duration: slider (default 5 min)
-- **Plugin Language**: English/Japanese/Chinese/Korean (controls UI display, auto‑detected from Obsidian)
+- **Plugin Language**: English/Japanese/Chinese/Korean (controls UI display only; auto‑detected from Obsidian)
 
 ### Language Settings Explained
 

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -159,7 +159,7 @@ export const en: TranslationResource = {
             transcriptionLanguage: 'Transcription Language',
             transcriptionLanguageDesc: 'Language for voice recognition and transcription. Auto-detection is recommended for best results.',
             pluginLanguage: 'Plugin Language',
-            pluginLanguageDesc: 'Set language for UI, voice processing, and correction dictionary',
+            pluginLanguageDesc: 'Set language for UI display',
             customDictionary: 'Custom Dictionary',
             customDictionaryDesc: 'Manage corrections used for post-processing',
             dictionaryDefinite: 'Definite Corrections (max {max})',


### PR DESCRIPTION
タイトル: feat(settings/docs): clean follow-up for #10 (transcriptionLanguage separation + docs alignment)

背景
- Issue #10（DEFAULT_TRANSCRIPTION_SETTINGS.language の既定整合）は、実装面は `feat/multilingual-improvements` に既に取り込まれています。
- 本PRは、ドキュメント（README/i18n）を実装方針に確実に揃える「クリーン」最小差分です。
  - 余計なコード変更や依存追加は含みません。

本PRの変更（最小差分）
- README（英/日）: Plugin Language が「UI 表示のみ」を制御することを明記（実装と整合）。
- i18n(en): `pluginLanguageDesc` を UI 専用の説明に修正（処理系への影響を示唆しない表現に是正）。

ベースに既に含まれている実装（再確認用）
- 設定分離: `transcriptionLanguage: 'auto'|'ja'|'en'|'zh'|'ko'` と `pluginLanguage` を分離（`src/interfaces/settings.ts`）。
- 自動検出: `getResolvedLanguage()` で `transcriptionLanguage==='auto'` の場合は Obsidian ロケールから `ja/zh/ko/en` を自動判定（`src/plugin/VoiceInputPlugin.ts`）。
- 呼び出し統合: `views` 側は `this.plugin.getResolvedLanguage()` を渡して `TranscriptionService.transcribeAudio(...)` を呼ぶ（`src/views/VoiceInputViewActions.ts`）。
- API送信: `TranscriptionService` は `language !== 'auto'` のときのみ form-data に `language` を付与（`src/core/transcription/TranscriptionService.ts`）。
- プロンプト: `buildTranscriptionPrompt(language)` は `ja` のみ付与。`auto`/非JAは付与なし。
- クリーニング: `cleanGPT4oResponse(text, language)` は言語別パターン + 汎用（「Output format:」「Format:」などコロン付き）で安全側に実装。
- 辞書補正: `enableTranscriptionCorrection` が true の場合は言語に関係なく適用。

受け入れ基準（AC）
- [ ] README の説明が「UI言語と認識言語の分離」「日本語のみ辞書補正」の方針と一致。
- [ ] en.ts の `pluginLanguageDesc` が UI 表示の説明に限定されている（処理系への影響を示唆しない）。
- [ ] 変更ファイルは `README.md` と `src/i18n/en.ts` のみ。コード/依存には差分なし。
- [ ] `npm run lint` / `npm run build-plugin` / `npm test` が成功（ローカル/CI）。

レビューチェックリスト（@copilot）
1) 差分の確認
   - Files changed に `README.md` と `src/i18n/en.ts` のみが並んでいることを確認。
2) 実装とドキュメントの整合性確認
   - `src/interfaces/settings.ts` に `transcriptionLanguage` と `pluginLanguage` の分離があること。
   - `src/plugin/VoiceInputPlugin.ts` に `getResolvedLanguage()`（auto 判定）と `detectPluginLanguage()`（ja/zh/ko/en）があること。
   - `src/views/VoiceInputViewActions.ts` が `getResolvedLanguage()` を渡していること。
   - `src/core/transcription/TranscriptionService.ts` が `language !== 'auto'` の場合のみ言語を送信し、`ja` 以外にプロンプトを付与しないこと、クリーニングと言語別検出を持つこと。
3) コマンド実行
   - `npm run lint` / `npm run build-plugin` / `npm test` を実行し、成功ログを本PRにコメントで貼付。
4) 余計な変更がないことの確認
   - `package.json` / `package-lock.json` / 依存関係 に差分がないこと。
   - 実行コードへの不要な修正が入っていないこと（本PRは Docs 整合のみ）。

スコープ外
- 実装仕様の追加変更（実装はベースブランチの最新仕様を前提）。
- 各言語（ja/zh/ko）での説明文の更新（必要であれば別PRで対処）。

マージ手順（想定）
- レビュー OK 後、`feat/multilingual-improvements` にマージ。
- 旧 PR #15 はクローズし、`copilot/fix-10` ブランチは削除（リモート/ローカル）。
- Issue #10 をクローズ（実装＋ドキュメント整合の完了として）。
